### PR TITLE
fix: 로그인/로그아웃 수정

### DIFF
--- a/src/components/commons/layout/header/index.tsx
+++ b/src/components/commons/layout/header/index.tsx
@@ -18,7 +18,7 @@ const FETCH_USER_LOGGED_IN = gql`
 export default function LayoutHeader() {
   const router = useRouter();
 
-  const { data } =
+  const { data, client } =
     useQuery<Pick<IQuery, "fetchUserLoggedIn">>(FETCH_USER_LOGGED_IN);
 
   const [accessToken, setAccessToken] = useRecoilState(accessTokenState);
@@ -31,10 +31,11 @@ export default function LayoutHeader() {
     void router.push("/login");
   };
 
-  const onClickMoveToLogout = () => {
+  const onClickMoveToLogout = async () => {
     const result = confirm("로그아웃 하시겠습니까?");
     if (result) {
       localStorage.removeItem("accessToken");
+      await client.clearStore();
       setAccessToken("");
     }
   };


### PR DESCRIPTION
## 개요 :mag:

로그아웃 후에 다른 아이디로 로그인하면 웹사이트 HEAD 부분의 이름이 변경되지 않는 현상이 있었습니다.

## 작업사항 :memo:
 - ApolloClient cache에 저장된 유저의 이름이 삭제되지 않고 남아있게되어 발생하는 문제였습니다.
 - 로그아웃 후 이전 cache들은 삭제하도록 useQuery의 client를 사용하였습니다.