### PR TITLE
fix: 자유게시판 목록 페이지 수정

### DIFF
--- a/src/components/units/board/list/BoardList.container.tsx
+++ b/src/components/units/board/list/BoardList.container.tsx
@@ -17,7 +17,7 @@ export default function BoardList() {
   const { data, refetch } = useQuery<
     Pick<IQuery, "fetchBoards" | "fetchBoardsCount">,
     IQueryFetchBoardsArgs | IQueryFetchBoardsCountArgs
-  >(FETCH_BOARDS_WITH_COUNT);
+  >(FETCH_BOARDS_WITH_COUNT, { fetchPolicy: "network-only" });
 
   const [startPage, setStartPage] = useState(1);
   const endPage = data ? Math.ceil(data.fetchBoardsCount / 10) : 1;


### PR DESCRIPTION
## 개요 :mag:

게시글 등록 후, 목록으로 가면 게시글이 보이지않는 현상이 있었습니다.

## 작업사항 :memo:

 - 게시글 목록을 보여주는 경우, fetchPolicy를 network-only 속성을 주어서 cache를 쓰지 않는 것으로 해결했습니다.