### PR TITLE
fix: 자유게시판 상세페이지 수정

### DIFF
--- a/src/components/units/board/detail/BoardDetail.presenter.tsx
+++ b/src/components/units/board/detail/BoardDetail.presenter.tsx
@@ -26,11 +26,24 @@ export default function BoardDetailUI(props: IBoardDetailProps) {
       <S.SliderWrapper>
         <Slider {...settings}>
           {props.data?.fetchBoard.images?.length ? (
-            props.data?.fetchBoard.images?.map((image, index) => (
-              <S.ImageWrapper key={index}>
-                {<S.Image src={`${NEXT_PUBLIC_IMAGE_STORE_URI}/${image}`} />}
-              </S.ImageWrapper>
-            ))
+            props.data?.fetchBoard.images?.map((image, index) =>
+              props.data?.fetchBoard.images?.map((image, index) =>
+                image.includes("petple-file-image") ? (
+                  <S.ImageWrapper key={index}>
+                    {
+                      <S.Image
+                        src={`${NEXT_PUBLIC_IMAGE_STORE_URI}/${image}`}
+                      />
+                    }
+                  </S.ImageWrapper>
+                ) : (
+                  <S.ImageWrapper key={index}>
+                    <S.Image src={process.env.NEXT_PUBLIC_DEFAULT_IMAGE_URI} />
+                    <S.ImageText>이미지 없음</S.ImageText>
+                  </S.ImageWrapper>
+                )
+              )
+            )
           ) : (
             <S.ImageWrapper>
               <S.Image src={process.env.NEXT_PUBLIC_DEFAULT_IMAGE_URI} />


### PR DESCRIPTION
 ## 개요 :mag:

이미지를 보여줄 때마다 텅 빈 이미지를 보여주는 현상이 있었습니다.

## 작업사항 :memo:

 - 강의에서 제공한 저장소의 이미지가 아닌 이 프로젝트만의 이미지 저장소에서 이미지를 불러와야해서 수정했습니다.